### PR TITLE
fixes for osx build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ endif(APPLE)
 # Find gnuradio build dependencies
 ########################################################################
 find_package(Doxygen)
-find_package(Boost REQUIRED chrono filesystem)
+find_package(Boost REQUIRED chrono filesystem unit_test_framework)
 find_package(gnuradio-pdu_utils REQUIRED)
 
 # ##############################################################################

--- a/lib/block_buffer_impl.cc
+++ b/lib/block_buffer_impl.cc
@@ -157,7 +157,7 @@ int block_buffer_impl::general_work(int noutput_items,
 
         // read as much as we can into the current buffer
         size_t to_read =
-            std::min((size_t)(ninput_items[0] - in_idx), d_nsamples - d_read_idx);
+            std::min<size_t>((size_t)(ninput_items[0] - in_idx), d_nsamples - d_read_idx);
 
 
         // update current rate
@@ -313,8 +313,8 @@ int block_buffer_impl::general_work(int noutput_items,
             int64_t numsamples_skipped =
                 (d_buf[d_writing].abs_read_idx == 0)
                     ? 0
-                    : std::max(d_buf[d_writing].abs_read_idx - d_last_abs_read_idx -
-                                   d_nsamples,
+                    : std::max<unsigned long long>(d_buf[d_writing].abs_read_idx -
+				   d_last_abs_read_idx - d_nsamples,
                                0lu);
 
             // if there's not already an rx_time tag, and some samples were skipped,
@@ -352,7 +352,7 @@ int block_buffer_impl::general_work(int noutput_items,
         }
 
         // write as much as we can from the current buffer
-        size_t to_write = std::min((size_t)(noutput_items - d_nreserved - out_idx),
+        size_t to_write = std::min<size_t>((size_t)(noutput_items - d_nreserved - out_idx),
                                    d_nsamples - d_write_idx);
 
         // write from buffer

--- a/lib/vita49_tcp_msg_source_impl.cc
+++ b/lib/vita49_tcp_msg_source_impl.cc
@@ -15,7 +15,7 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/sandia_utils/constants.h>
 #include <arpa/inet.h>
-#include <endian.h>
+#include <sys/types.h>          // cross platform include for endian.h
 
 namespace gr
 {


### PR DESCRIPTION
This resolves two issues building on OSX:
1. OSX uses `<machine/endian.h>` instead of `<endian.h>`, and while a conditional include could be done with preprocessor directives (or passing `CFLAGS="$CFLAGS -I~/usr/include/machine` conditionally in CMake), using `<sys/types.h>` (which is cross platform) seems easier.
2. Stops relying on template argument deduction for `std::min` and `std::max` calls. Or maybe you would prefer to cast these to the same type... if so i can update to that behavior, let me know. Either way whats in here fails on OSX.